### PR TITLE
docs: add image asset management TODO to SPEC.md

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -58,6 +58,13 @@ Branch: `feat/modernize-portfolio` (not yet pushed/merged)
   - Others TBD
 - [ ] Add screenshots/images for new project cards
 
+### Image Asset Management
+
+- [ ] Move images out of the git repo — binary assets bloat the repo and slow clones
+- [ ] Evaluate options: Cloudinary, Vercel Blob, S3 + CloudFront, or Git LFS
+- [ ] Update image references in data files (`projects.ts`, `trips.ts`) to pull from remote URLs
+- [ ] Remove `public/images/` from the repo once remote hosting is confirmed working
+
 ### Future Enhancements (Low Priority)
 
 - Enable Santa Cruz trip on Travel page (data already in `trips.ts`, just needs to be unfiltered)


### PR DESCRIPTION
## Summary
- Adds a new "Image Asset Management" section to the SPEC.md TODO list
- Tracks the need to move binary image assets out of the git repo to a remote hosting solution (Cloudinary, Vercel Blob, S3 + CloudFront, or Git LFS)

## Test plan
- [x] Verify SPEC.md renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)